### PR TITLE
Added BL reply to incoming messages

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -14,3 +14,7 @@ controller.hears("hello", "direct_message,direct_mention,mention", function(bot,
 	bot.reply(message, "Hello from the Zoid side !");
 	bot.reply(message, "https://media.giphy.com/media/az3XlqP9zQ9ry/giphy.gif");
 });
+
+controller.hears("bl", "mesage_received", function(bot, message) {
+	bot.reply(message, ":bl:");
+});


### PR DESCRIPTION
# Scope

In order to maintain consistency with the other bot's actions in relation to incoming messages, the necessity of a "BL" reply by ZoidBot was becoming a necessity. As such, it was decided to create an action when the "BL" text was detected in a message handled by ZoidBot.

# Choice of the action

A long debate was made to choose the reaction the bot should have when detecting the BL message. We choose to settle on the BL emoticon reply, based mostly on the fact that I created this emoticon but also because it wasn't already done by other bots.  
It was decided not to mention anyone in this reply, in order to keep the neutrality of the action at its maximum. This way, the bot can both agree or disagree with the original message sender, depending of the analysis of the sender, the original receiver or any other involved party.

# Resolution of the problem.

After careful analysis, it was decided to add a custom action to the already existing controller. Indeed, the alternative would have been to extend the already existing controller, which would have limited the action to messages both containing "bl" and "hello".  
The controller was added based on the specification given by BotKit in order to catch all incoming messages. The reply is generic, and was chosen to be a reply and not an independent message in order to keep the conversation focused on the sender.