### PR TITLE
Fix : wrong parameter for BL message handling

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -15,6 +15,6 @@ controller.hears("hello", "direct_message,direct_mention,mention", function(bot,
 	bot.reply(message, "https://media.giphy.com/media/az3XlqP9zQ9ry/giphy.gif");
 });
 
-controller.hears("bl", "mesage_received", function(bot, message) {
+controller.hears("bl", "message_received", function(bot, message) {
 	bot.reply(message, ":bl:");
 });


### PR DESCRIPTION
# Scope

The #1 pull request had a wrong parameter in its message filter. This resulted in the command being ineffective.  
This was due to a negligence of the #1 author who missed an occasion to check the PR and to do a `git add`. Shame on him.

# Solution

The "message_received" filter was properly added to the command.
This solution was better than reverting the previous PR as it allows me to be once again a PR author, and that's cool.

# bl
bl.